### PR TITLE
fix(satellite): hide activity impact accordion sections

### DIFF
--- a/src/components/satellite/SatelliteAccordion.tsx
+++ b/src/components/satellite/SatelliteAccordion.tsx
@@ -6,14 +6,10 @@ import { getSession } from '@/actions/getSession';
 import Accordion from '@/ui/accordion/accordion';
 import { isAgencyApprover, isSatteliteOperator } from '@/utils/Roles';
 
-import { SatelliteActivityEvents } from './SatelliteActivityEvents';
 import { SatelliteAdditionalInformations } from './SatelliteAdditionalInformation';
 import { SatelliteConjunctionEvents } from './SatelliteConjunctionEvents';
 import { SatelliteEphemerisData } from './SatelliteEphemerisData';
-import { SatelliteFragmentationsEvents } from './SatelliteFragmentationsEvents';
 import { SatelliteInformation } from './SatelliteInformation';
-import { SatellitePositionHistory } from './SatellitePositionHistory';
-import { SatelliteReentriesEvents } from './SatelliteReentriesEvents';
 
 type SatelliteAccordionProps = {
   noradId: string;
@@ -78,7 +74,7 @@ const SatelliteAccordion = async ({
           },
         ]}
       />
-      <h2 data-anchor="potential-impact" className="govuk-heading-l">{t('activity_information')}</h2>
+      {/* <h2 data-anchor="potential-impact" className="govuk-heading-l">{t('activity_information')}</h2>
       <Accordion
         id="activity-events"
         addAnchor={false}
@@ -118,7 +114,7 @@ const SatelliteAccordion = async ({
             content: <SatelliteFragmentationsEvents noradId={noradId} />,
           },
         ]}
-      />
+      /> */}
     </>
 
   );


### PR DESCRIPTION
Temporarily disable activity, position history, re-entry, and fragmentation accordions on the satellite detail page.